### PR TITLE
Fix Name in index.theme files

### DIFF
--- a/Papirus-Dark/index.theme
+++ b/Papirus-Dark/index.theme
@@ -1,6 +1,6 @@
 [Icon Theme]
-Name=Papirus-Dark
-Comment=A simple and modern icon theme.
+Name=Pop-Dark
+Comment=System76 Pop icon theme for Linux.
 Inherits=breeze-dark,ubuntu-mono-dark,Mint-X,elementary,gnome,hicolor
 
 DesktopDefault=48

--- a/Papirus-Light/index.theme
+++ b/Papirus-Light/index.theme
@@ -1,6 +1,6 @@
 [Icon Theme]
-Name=Papirus-Light
-Comment=A simple and modern icon theme.
+Name=Pop-Light
+Comment=System76 Pop icon theme for Linux.
 Inherits=breeze,ubuntu-mono-dark,Mint-X,elementary,gnome,hicolor
 
 DesktopDefault=48

--- a/Papirus/index.theme
+++ b/Papirus/index.theme
@@ -1,6 +1,6 @@
 [Icon Theme]
-Name=Papirus
-Comment=A simple and modern icon theme.
+Name=Pop
+Comment=System76 Pop icon theme for Linux.
 Inherits=breeze,ubuntu-mono-dark,Mint-X,elementary,gnome,hicolor
 
 DesktopDefault=48

--- a/ePapirus/index.theme
+++ b/ePapirus/index.theme
@@ -1,6 +1,6 @@
 [Icon Theme]
-Name=ePapirus
-Comment=A simple and modern icon theme.
+Name=ePop
+Comment=System76 Pop icon theme for Linux.
 Inherits=elementary,ubuntu-mono-dark,breeze,Mint-X,gnome,hicolor
 
 DesktopDefault=48


### PR DESCRIPTION
This makes Pop properly show up in icon theme selectors as Pop rather than Papirus.