### PR TITLE
use crescent moon for system-suspend-symbolic icon

### DIFF
--- a/Papirus-Dark/symbolic/actions/system-suspend-symbolic.svg
+++ b/Papirus-Dark/symbolic/actions/system-suspend-symbolic.svg
@@ -1,9 +1,64 @@
-<?xml version='1.0' encoding='UTF-8' standalone='no'?>
-<svg height="16" style="enable-background:new" version="1.1" width="16" xmlns="http://www.w3.org/2000/svg">
- <title>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   height="16"
+   style="enable-background:new"
+   version="1.1"
+   width="16"
+   id="svg2"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="system-suspend-symbolic.svg">
+  <metadata
+     id="metadata14">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>
+  Paper Symbolic Icon Theme
+ </dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs12" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1248"
+     inkscape:window-height="1388"
+     id="namedview10"
+     showgrid="false"
+     inkscape:zoom="41.7193"
+     inkscape:cx="10.900702"
+     inkscape:cy="7.903374"
+     inkscape:window-x="5792"
+     inkscape:window-y="24"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg2" />
+  <title
+     id="title4">
   Paper Symbolic Icon Theme
  </title>
- <g transform="translate(-465.00043,-204.99664)">
-  <path d="m 473.0002,207 a 6,6 0 0 0 -6,6 6,6 0 0 0 6,6 6,6 0 0 0 6,-6 6,6 0 0 0 -6,-6 z m 0,2 a 4,4 0 0 1 4,4 4,4 0 0 1 -0.13281,1 l -7.73633,0 a 4,4 0 0 1 -0.13086,-1 4,4 0 0 1 4,-4 z m -2.63867,7 5.27734,0 a 4,4 0 0 1 -2.63867,1 4,4 0 0 1 -2.63867,-1 z" style="opacity:1;fill:#d3dae3;fill-opacity:1;"/>
- </g>
+  <path
+     d="m 9.41413,2.10405 c 2.30063,0.54123 4.15146,2.41197 4.53224,4.92788 0.50159,3.31407 -1.72318,6.4579 -4.9918,6.9869 C 6.47317,14.42042 4.1151,13.1975 2.90326,11.14407 4.20823,11.52575 5.41309,11.46655 6.45268,10.89565 8.15072,9.96315 9.50042,8.61078 9.90599,6.22115 10.058,5.32547 10.24103,3.31482 9.41414,2.10402 Z"
+     style="color:#d3dae3;fill:#d3dae3;fill-opacity:1;stroke:none;stroke-width:1.09279799;stroke-opacity:1;enable-background:new"
+     class="ColorScheme-ButtonBackground"
+     id="path5"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="csscascc" />
 </svg>

--- a/Papirus/symbolic/actions/system-suspend-symbolic.svg
+++ b/Papirus/symbolic/actions/system-suspend-symbolic.svg
@@ -1,9 +1,68 @@
-<?xml version='1.0' encoding='UTF-8' standalone='no'?>
-<svg height="16" style="enable-background:new" version="1.1" width="16" xmlns="http://www.w3.org/2000/svg">
- <title>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   height="16"
+   style="enable-background:new"
+   version="1.1"
+   width="16"
+   id="svg2"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="system-suspend-symbolic.svg">
+  <metadata
+     id="metadata14">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>
+  Paper Symbolic Icon Theme
+ </dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs12" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1248"
+     inkscape:window-height="1388"
+     id="namedview10"
+     showgrid="false"
+     inkscape:zoom="41.7193"
+     inkscape:cx="8.1030675"
+     inkscape:cy="12.267101"
+     inkscape:window-x="4545"
+     inkscape:window-y="24"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="g6" />
+  <title
+     id="title4">
   Paper Symbolic Icon Theme
  </title>
- <g transform="translate(-465.00043,-204.99664)">
-  <path d="m 473.0002,207 a 6,6 0 0 0 -6,6 6,6 0 0 0 6,6 6,6 0 0 0 6,-6 6,6 0 0 0 -6,-6 z m 0,2 a 4,4 0 0 1 4,4 4,4 0 0 1 -0.13281,1 l -7.73633,0 a 4,4 0 0 1 -0.13086,-1 4,4 0 0 1 4,-4 z m -2.63867,7 5.27734,0 a 4,4 0 0 1 -2.63867,1 4,4 0 0 1 -2.63867,-1 z" style="opacity:1;fill:#5c616c;fill-opacity:1;"/>
- </g>
+  <g
+     transform="translate(-465.00043,-204.99664)"
+     id="g6">
+    <path
+       d="m 474.41456,207.10069 c 2.30063,0.54123 4.15146,2.41197 4.53224,4.92788 0.50159,3.31407 -1.72318,6.4579 -4.9918,6.9869 -2.4814,0.40159 -4.83947,-0.82133 -6.05131,-2.87476 1.30497,0.38168 2.50983,0.32248 3.54942,-0.24842 1.69804,-0.9325 3.04774,-2.28487 3.45331,-4.6745 0.15201,-0.89568 0.33504,-2.90633 -0.49185,-4.11713 z"
+       style="color:#d3dae3;fill:#5c616c;fill-opacity:1;stroke-width:1.09279799;stroke:none;stroke-opacity:1"
+       class="ColorScheme-ButtonBackground"
+       id="path5"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="csscascc" />
+  </g>
 </svg>


### PR DESCRIPTION
The circle with a line in the lower half is a little unintuitive.  Most users can figure its meaning from context when placed next to the power and lock icons, but the crescent moon is more intuitive and matches the keyboard icon for suspend.  I believe this makes it a better choice for suspend icon.